### PR TITLE
Add "default" target

### DIFF
--- a/custom_components/remote_notifications/__init__.py
+++ b/custom_components/remote_notifications/__init__.py
@@ -78,7 +78,10 @@ async def handle_data(data, hass, config):
 				target_services.append(configured_target_service_map[target])
 	
 	if len(target_services) == 0:
-		target_services.append(configured_target_service_map["conrad"])
+		if "default" in configured_target_service_map:
+			target_services.append(configured_target_service_map["default"])
+		else:
+			raise Exception("No known targets called and no default target is set either")
 	
 	if "clearNotification" in data and data["clearNotification"] == True and "tag" in data:
 		notification_message = 'clear_notification'

--- a/custom_components/remote_notifications/manifest.json
+++ b/custom_components/remote_notifications/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "remote_notifications",
     "name": "Remote Notifications",
-	"version": "1.2.0",
+	"version": "1.3.0",
     "documentation": "https://github.com/abductist/remote_notifications",
     "dependencies": [
         "webhook"


### PR DESCRIPTION
If no known targets are called and a "default" target is specified in the map, the default target will be used for the notification.